### PR TITLE
Ccp 1845- Update extension for compatibility with PWA 6.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0]
+### Added
+- Support for PWA 6.9.0. 
+
 ## [1.0.0]
 ### Added
 - Initial extension release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.1.0]
+## [1.1.0] - 11-25-2019
 ### Added
 - Support for PWA 6.9.0. 
 
 ## [1.0.0]
 ### Added
 - Initial extension release.
+
+
+[1.1.1]: https://github.com/shopgate-professional-services/ext-product-image-badges/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/shopgate-professional-services/ext-product-image-badges/releases/v1.0.0

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "id": "@shopgate-project/product-image-badges",
   "components": [
     {
@@ -13,6 +13,12 @@
       "type": "portals",
       "path": "frontend/portals/ComponentProductImageBefore",
       "target": "component.product-image.before"
+    },
+    {
+      "id": "ProductItemImageBefore",
+      "type": "portals",
+      "path": "frontend/portals/ProductItemImageBefore",
+      "target": "product-item.image.before"
     }
   ],
   "configuration": {

--- a/frontend/components/Badge/styles.js
+++ b/frontend/components/Badge/styles.js
@@ -2,7 +2,7 @@ import { css } from 'glamor';
 import { cardBadgeRatio, gridBadgeRatio, pdpBadgeRatio } from '../../config';
 
 const container = css({
-  display: 'float',
+  display: 'inline',
   position: 'absolute',
   right: 0,
   top: 0,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/product-image-badges",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Extension will allow a user to display a image badge on a product image based on tag or property.",
   "license": "UNLICENSED",
   "scripts": {
@@ -10,15 +10,15 @@
     "coverage:watch": "npm run coverage -- --watch"
   },
   "devDependencies": {
-    "@shopgate/engage": "^6.7.2",
-    "@shopgate/eslint-config": "^6.7.2",
-    "@shopgate/pwa-common": "^6.7.2",
-    "@shopgate/pwa-common-commerce": "^6.7.2",
-    "@shopgate/pwa-core": "^6.7.2",
+    "@shopgate/engage": "^6.9.0",
+    "@shopgate/eslint-config": "^6.9.0",
+    "@shopgate/pwa-common": "^6.9.0",
+    "@shopgate/pwa-common-commerce": "^6.9.0",
+    "@shopgate/pwa-core": "^6.9.0",
     "jest": "^22.4.2",
-    "@shopgate/pwa-unit-test": "^6.7.2",
-    "@shopgate/pwa-ui-ios": "^6.7.2",
-    "@shopgate/pwa-ui-shared": "^6.7.2",
+    "@shopgate/pwa-unit-test": "^6.9.0",
+    "@shopgate/pwa-ui-ios": "^6.9.0",
+    "@shopgate/pwa-ui-shared": "^6.9.0",
     "babel-core": "^6.26.0",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -39,6 +39,6 @@
     "react-transform-catch-errors": "^1.0.2"
   },
   "peerDependencies": {
-    "@shopgate/engage": "^6.7.2"
+    "@shopgate/engage": "^6.9.0"
   }
 }

--- a/frontend/portals/ProductItemImageBefore/index.jsx
+++ b/frontend/portals/ProductItemImageBefore/index.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  PRODUCT_GRID_LOCATION,
+} from '../../constants';
+import Badge from '../../components/Badge';
+import connect from '../connector';
+
+/**
+ * @param {Object} badgeInfo badge images to display
+ * @returns {JSX}
+ */
+const ProductItemImageBefore = ({ badgeInfo }) => {
+  if (!badgeInfo || badgeInfo.length === 0) {
+    return null;
+  }
+
+  return <Badge location={PRODUCT_GRID_LOCATION} badgeInfo={badgeInfo} />;
+};
+
+ProductItemImageBefore.propTypes = {
+  badgeInfo: PropTypes.arrayOf(PropTypes.string),
+};
+
+ProductItemImageBefore.defaultProps = {
+  badgeInfo: null,
+};
+
+export default connect(ProductItemImageBefore);

--- a/frontend/portals/ProductItemPriceBefore/index.jsx
+++ b/frontend/portals/ProductItemPriceBefore/index.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  PRODUCT_GRID_LOCATION,
+} from '../../constants';
 import Badge from '../../components/Badge';
 import connect from '../connector';
 
@@ -9,7 +12,7 @@ import connect from '../connector';
  * @returns {JSX}
  */
 const ProductItemPriceBefore = ({ location, badgeInfo }) => {
-  if (!location || !badgeInfo || badgeInfo.length === 0) {
+  if (!location || location === PRODUCT_GRID_LOCATION || !badgeInfo || badgeInfo.length === 0) {
     return null;
   }
 
@@ -17,12 +20,13 @@ const ProductItemPriceBefore = ({ location, badgeInfo }) => {
 };
 
 ProductItemPriceBefore.propTypes = {
-  location: PropTypes.string.isRequired,
   badgeInfo: PropTypes.arrayOf(PropTypes.string),
+  location: PropTypes.string,
 };
 
 ProductItemPriceBefore.defaultProps = {
   badgeInfo: null,
+  location: null,
 };
 
 export default connect(ProductItemPriceBefore);


### PR DESCRIPTION
Can use shop no: 31866 and example config:
`{
  "badgeMap": [
    {
      "src": "http://data.shopgate.com/shop_widget_images/16527/493f97fdafdaf96d380b80f87c59a82e.min.png",
      "triggerTags": [
        "preorder",
        "Preorder"
      ],
      "triggerProps": []
    },
    {
      "src": "http://data.shopgate.com/shop_widget_images/16527/827475f88aa3ab70294b2ea87b26a41c.min.png",
      "triggerTags": [
        "gs24"
      ],
      "triggerProps": []
    }
  ],
  "badgeDisplayCount": 2,
  "gridBadgeRatio": {
    "width": 50,
    "height": 70.42
  },
  "cardBadgeRatio": {
    "width": 40,
    "height": 56.33
  },
  "pdpBadgeRatio": {
    "width": 60,
    "height": 84.5
  }
}
`
PWA 6.9.0 added different styling to product grid items that applied to the  product-item.price.before portal. Used a different portal position that allowed us to keep previous styling logic.