### PR TITLE
Support text-based product badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.7.0] - 02-07-2025
+### Added
+- Add support for text-based badges
+
 ## [1.6.0] - 12-03-2025
 ### Added
 - Improved accessibility for screen readers
@@ -37,6 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Initial extension release.
 
 
+[1.7.0]: https://github.com/shopgate-professional-services/ext-product-image-badges/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/shopgate-professional-services/ext-product-image-badges/compare/v1.5.0...v1.6.0
 [1.3.0]: https://github.com/shopgate-professional-services/ext-product-image-badges/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/shopgate-professional-services/ext-product-image-badges/compare/v1.1.0...v1.2.0

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ Example Value:
       ],
       "src": "exampleImage2.com",
       "altText": "a meaningful description of the image for accessibility"
+    },
+    {
+      "text": "NEU!!",
+      "style": {
+        "borderRadius": "25px",
+        "backgroundColor": "red"
+      },
+      "triggerTags": [],
+      "triggerProps": [
+        {
+          "label": "exampleTriggerProp-2",
+          "value": "yes"
+        }
+      ]
     }
   ]
 }

--- a/frontend/components/Badge/index.jsx
+++ b/frontend/components/Badge/index.jsx
@@ -75,37 +75,65 @@ const CardBadge = ({ badgeInfo, badgePosition }) => {
     }
 
     if (productListType === 'productSlider') {
-      return badgeInfo.map(({ src, altText }, index) => (
-        <img
-          className={styles.badgeSliders}
-          src={src}
-          alt={altText}
-          aria-hidden={!altText}
-          key={index.toString()}
-        />
-      ));
+      return badgeInfo.map(({
+        src, altText, text, style,
+      }, index) => {
+        if (text) {
+          return (
+            <div style={style} className="product-badge__text" key={index.toString()}>{text}</div>
+          );
+        }
+        return (
+          <img
+            className={styles.badgeSliders}
+            src={src}
+            alt={altText}
+            aria-hidden={!altText}
+            key={index.toString()}
+          />
+        );
+      });
     }
 
     if (productListType === 'productGrid') {
-      return badgeInfo.map(({ src, altText }, index) => (
+      return badgeInfo.map(({
+        src, altText, text, style,
+      }, index) => {
+        if (text) {
+          return (
+            <div style={style} className="product-badge__text" key={index.toString()}>{text}</div>
+          );
+        }
+        return (
+          <img
+            className={styles.badgeLists}
+            src={src}
+            alt={altText}
+            aria-hidden={!altText}
+            key={index.toString()}
+          />
+        );
+      });
+    }
+
+    return badgeInfo.map(({
+      src, altText, text, style,
+    }, index) => {
+      if (text) {
+        return (
+          <div style={style} className="product-badge__text" key={index.toString()}>{text}</div>
+        );
+      }
+      return (
         <img
-          className={styles.badgeLists}
+          className={styles.badge}
           src={src}
           alt={altText}
           aria-hidden={!altText}
           key={index.toString()}
         />
-      ));
-    }
-    return badgeInfo.map(({ src, altText }, index) => (
-      <img
-        className={styles.badge}
-        src={src}
-        alt={altText}
-        aria-hidden={!altText}
-        key={index.toString()}
-      />
-    ));
+      );
+    });
   }, [badgeInfo, productListType]);
 
   const containerClasses = useMemo(() => {
@@ -150,7 +178,7 @@ const CardBadge = ({ badgeInfo, badgePosition }) => {
 };
 
 CardBadge.propTypes = {
-  badgeInfo: PropTypes.arrayOf(PropTypes.string).isRequired,
+  badgeInfo: PropTypes.arrayOf(PropTypes.object).isRequired,
   badgePosition: PropTypes.string.isRequired,
 };
 

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,1 +1,0 @@
-module.exports = require('@shopgate/pwa-unit-test/jest.config');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,21 +1,13 @@
 {
   "name": "@shopgate-project/product-image-badges",
-  "description": "Extension will allow a user to display a image badge on a product image based on tag or property.",
+  "description": "Extension will allow a user to display an image badge on a product image based on tag or property.",
   "license": "UNLICENSED",
-  "scripts": {
-    "test": "jest",
-    "test:watch": "npm run test -- --watch",
-    "coverage": "jest --coverage",
-    "coverage:watch": "npm run coverage -- --watch"
-  },
   "devDependencies": {
     "@shopgate/engage": "^6.10.0",
     "@shopgate/eslint-config": "^6.10.0",
     "@shopgate/pwa-common": "^6.10.0",
     "@shopgate/pwa-common-commerce": "^6.10.0",
     "@shopgate/pwa-core": "^6.10.0",
-    "jest": "^22.4.2",
-    "@shopgate/pwa-unit-test": "^6.10.0",
     "@shopgate/pwa-ui-ios": "^6.10.0",
     "@shopgate/pwa-ui-shared": "^6.10.0",
     "babel-core": "^6.26.0",

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -11,9 +11,13 @@ export const getBadgeInfo = createSelector(
     }
 
     const badgeInfo = badgeMap.filter(badge => isTriggered(productData, badge))
-      .map(({ src, altText }) => ({
+      .map(({
+        src, altText, text, style,
+      }) => ({
         src,
         altText,
+        text,
+        style,
       }));
 
     if (!badgeInfo) {


### PR DESCRIPTION
We now enable text-based product badges. Instead of providing an image with a source url, it is now possible to configure "text" and "style" for the badgeMap array in the extension config. As with the image badges, this would apply to the product images on the product detail page, the product sliders, and the product grid.